### PR TITLE
Expose listeners

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,6 +28,32 @@ class _MyAppState extends State<MyApp> {
         _imageData = imgData;
       });
     });
+
+    /// This is how any part of your app could listen to drag events
+    /// E.g. to update other UI once something is dragged
+    FlutterNativeDragNDrop.instance.addDragEventListener(onDragEvent);
+  }
+
+  bool isDragging = false;
+  void onDragEvent(DragEvent e) {
+    if (e is DragBeginEvent) {
+      setState(() {
+        isDragging = true;
+      });
+      return;
+    }
+    if (e is DragEndedEvent) {
+      setState(() {
+        isDragging = false;
+      });
+      return;
+    }
+  }
+
+  @override
+  void dispose() {
+    FlutterNativeDragNDrop.instance.removeDragEventListener(onDragEvent);
+    super.dispose();
   }
 
   @override
@@ -35,7 +61,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
         home: Scaffold(
             appBar: AppBar(
-              title: const Text('Native drag & drop example'),
+              title: isDragging ? const Text('Its dragging time') : const Text('Native drag & drop example'),
             ),
             body: Center(
                 child: Row(
@@ -63,8 +89,7 @@ class _MyAppState extends State<MyApp> {
                     });
                   },
                   onDragDone: (details) {
-                    AssetImage droppedImage =
-                        details.items.first.data! as AssetImage;
+                    AssetImage droppedImage = details.items.first.data! as AssetImage;
                     setState(() {
                       _dragging = false;
                       _img = droppedImage;
@@ -76,16 +101,12 @@ class _MyAppState extends State<MyApp> {
                 ),
                 const SizedBox(width: 15),
                 NativeDraggable(
-                  child: const Image(
-                      height: 200,
-                      width: 200,
-                      image: AssetImage("assets/maldives.jpg")),
+                  child: const Image(height: 200, width: 200, image: AssetImage("assets/maldives.jpg")),
                   fileStreamCallback: passFileContent,
                   fileItems: [
                     NativeDragFileItem(
                         fileName: "maldives.jpeg",
-                        fileSize:
-                            _imageData != null ? _imageData!.lengthInBytes : 0,
+                        fileSize: _imageData != null ? _imageData!.lengthInBytes : 0,
                         data: const AssetImage("assets/maldives.jpg"))
                   ],
                 )
@@ -94,10 +115,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   Stream<Uint8List> passFileContent(
-      NativeDragItem<Object> item,
-      String fileName,
-      String url,
-      ProgressController progressController) async* {
+      NativeDragItem<Object> item, String fileName, String url, ProgressController progressController) async* {
     final buffer = _imageData!.buffer.asUint8List();
     final range = buffer.length ~/ 10;
 

--- a/lib/flutter_native_drag_n_drop.dart
+++ b/lib/flutter_native_drag_n_drop.dart
@@ -2,3 +2,5 @@ export 'src/native_draggable.dart';
 export 'src/native_drop_target.dart';
 export 'src/native_drag_item.dart';
 export 'src/progress_controller.dart';
+export 'src/channel.dart';
+export 'src/events.dart';

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -77,53 +77,45 @@ class FlutterNativeDragNDrop {
       case "draggingEntered":
         final position = (call.arguments as List).cast<double>();
         _offset = Offset(position[0], position[1]);
-        _notifyDropEvent(
-            DropEnterEvent(location: _offset!, items: _draggedItems));
+        _notifyDropEvent(DropEnterEvent(location: _offset!, items: _draggedItems));
         break;
       case "draggingUpdated":
         final position = (call.arguments as List).cast<double>();
         _offset = Offset(position[0], position[1]);
-        _notifyDropEvent(
-            DropUpdateEvent(location: _offset!, items: _draggedItems));
+        _notifyDropEvent(DropUpdateEvent(location: _offset!, items: _draggedItems));
         break;
       case "draggingExited":
-        _notifyDropEvent(DropExitEvent(
-            location: _offset ?? Offset.zero, items: _draggedItems));
+        _notifyDropEvent(DropExitEvent(location: _offset ?? Offset.zero, items: _draggedItems));
         _offset = null;
         break;
       case "performDragOperation":
-        _notifyDropEvent(DropDoneEvent(
-            location: _offset ?? Offset.zero, items: _draggedItems));
+        _notifyDropEvent(DropDoneEvent(location: _offset ?? Offset.zero, items: _draggedItems));
         _offset = null;
         break;
       case "draggingBegin":
         final arguments = Map.from(call.arguments);
         final id = arguments["id"] as String;
         final position = (arguments["position"] as List).cast<double>();
-        _notifyDragEvent(
-            id, DragBeginEvent(location: Offset(position[0], position[1])));
+        _notifyDragEvent(id, DragBeginEvent(location: Offset(position[0], position[1])));
         break;
       case "draggingMoved":
         final arguments = Map.from(call.arguments);
         final id = arguments["id"] as String;
         final position = (arguments["position"] as List).cast<double>();
-        _notifyDragEvent(
-            id, DragMovedEvent(location: Offset(position[0], position[1])));
+        _notifyDragEvent(id, DragMovedEvent(location: Offset(position[0], position[1])));
         break;
       case "draggingEnded":
         final arguments = Map.from(call.arguments);
         final id = arguments["id"] as String;
         final position = (arguments["position"] as List).cast<double>();
-        _notifyDragEvent(
-            id, DragEndedEvent(location: Offset(position[0], position[1])));
+        _notifyDragEvent(id, DragEndedEvent(location: Offset(position[0], position[1])));
         break;
       case "fileStreamCallback":
         final arguments = Map.from(call.arguments);
         final id = arguments["id"] as String;
         final fileName = arguments["fileName"] as String;
         final url = arguments["url"] as String;
-        final item = _draggedItems.firstWhere((i) => i.name == fileName)
-            as NativeDragFileItem;
+        final item = _draggedItems.firstWhere((i) => i.name == fileName) as NativeDragFileItem;
         _notifyFileStreamEvent(id, FileStreamEvent(item, fileName, url));
         break;
       default:
@@ -165,20 +157,12 @@ class FlutterNativeDragNDrop {
   _listenToFileStream(String id, String fileName, Stream<Uint8List> stream) {
     stream.listen(
       (data) {
-        _channel.invokeMethod("feedFileStream", <String, dynamic>{
-          "id": id,
-          "fileName": fileName,
-          "data": data,
-          "status": "kWriting"
-        });
+        _channel.invokeMethod(
+            "feedFileStream", <String, dynamic>{"id": id, "fileName": fileName, "data": data, "status": "kWriting"});
       },
       onDone: () {
-        _channel.invokeMethod("feedFileStream", <String, dynamic>{
-          "id": id,
-          "fileName": fileName,
-          "data": null,
-          "status": "kEnded"
-        });
+        _channel.invokeMethod(
+            "feedFileStream", <String, dynamic>{"id": id, "fileName": fileName, "data": null, "status": "kEnded"});
       },
     );
   }

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -154,7 +154,7 @@ class FlutterNativeDragNDrop {
   void _notifyDragEvent(String id, DragEvent event) {
     for (final listener in _dragEventListeners) {
       listener(event);
-      }
+    }
     final listener = _draggableListeners[id];
     assert(listener != null, "Drag Event for non existent listener");
     listener?.onDragEvent(event);

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -20,6 +20,7 @@ class FlutterNativeDragNDrop {
   Offset? _offset;
 
   var _initialized = false;
+  @protected
   init() {
     if (_initialized) {
       return;
@@ -31,8 +32,9 @@ class FlutterNativeDragNDrop {
   }
 
   /// This method creates the draggable view and dropTargetView on native side
-  setDraggableView<T extends Object>(String id, Offset position, Size size,
-      Uint8List? image, List<NativeDragItem> items) async {
+  @protected
+  setDraggableView<T extends Object>(
+      String id, Offset position, Size size, Uint8List? image, List<NativeDragItem> items) async {
     _draggedItems = items;
 
     if (items.first is NativeDragFileItem) {
@@ -62,14 +64,14 @@ class FlutterNativeDragNDrop {
   }
 
   /// This method removes the draggable view and dropTargetView on native side
+  @protected
   removeDraggableView(String id) async {
-    await _channel
-        .invokeMethod("removeDraggableView", <String, dynamic>{"id": id});
+    await _channel.invokeMethod("removeDraggableView", <String, dynamic>{"id": id});
   }
 
+  @protected
   updateProgress(String id, String fileName, int count) {
-    _channel.invokeMethod("updateProgress",
-        <String, dynamic>{"id": id, "fileName": fileName, "count": count});
+    _channel.invokeMethod("updateProgress", <String, dynamic>{"id": id, "fileName": fileName, "count": count});
   }
 
   Future<dynamic> _handleMethodChannel(MethodCall call) async {
@@ -129,10 +131,14 @@ class FlutterNativeDragNDrop {
     }
   }
 
+  /// Used by native drop target
+  @protected
   void addRawDropEventListener(RawDropListener listener) {
     _dropListeners.add(listener);
   }
 
+  /// Used by native drop target
+  @protected
   void removeRawDropEventListener(RawDropListener listener) {
     _dropListeners.remove(listener);
   }
@@ -167,10 +173,14 @@ class FlutterNativeDragNDrop {
     );
   }
 
+  /// Used by native draggable
+  @protected
   void addDraggableListener(d.DraggableState listener) {
     _draggableListeners.add(listener);
   }
 
+  /// Used by native draggable
+  @protected
   void removeDraggableListener(d.DraggableState listener) {
     _draggableListeners.remove(listener);
   }

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -56,7 +56,7 @@ class FlutterNativeDragNDrop {
         "image": image,
         "names": fileItems.map((e) => e.name).toList(),
         "fileNames": fileItems.map((e) => e.fileName).toList(),
-        "fileSizes": fileItems.map((e) => e.fileSize).toList()
+        "fileSizes": fileItems.map((e) => e.fileSize).toList(),
       });
     } else {
       await _channel.invokeMethod("setDraggableView", <String, dynamic>{
@@ -66,7 +66,7 @@ class FlutterNativeDragNDrop {
         "width": size.width,
         "height": size.height,
         "image": image,
-        "names": _draggedItems.map((e) => e.name).toList()
+        "names": _draggedItems.map((e) => e.name).toList(),
       });
     }
   }
@@ -74,12 +74,22 @@ class FlutterNativeDragNDrop {
   /// This method removes the draggable view and dropTargetView on native side
   @protected
   removeDraggableView(String id) async {
-    await _channel.invokeMethod("removeDraggableView", <String, dynamic>{"id": id});
+    await _channel.invokeMethod(
+      "removeDraggableView",
+      <String, dynamic>{"id": id},
+    );
   }
 
   @protected
   updateProgress(String id, String fileName, int count) {
-    _channel.invokeMethod("updateProgress", <String, dynamic>{"id": id, "fileName": fileName, "count": count});
+    _channel.invokeMethod(
+      "updateProgress",
+      <String, dynamic>{
+        "id": id,
+        "fileName": fileName,
+        "count": count,
+      },
+    );
   }
 
   Future<dynamic> _handleMethodChannel(MethodCall call) async {
@@ -171,11 +181,25 @@ class FlutterNativeDragNDrop {
     stream.listen(
       (data) {
         _channel.invokeMethod(
-            "feedFileStream", <String, dynamic>{"id": id, "fileName": fileName, "data": data, "status": "kWriting"});
+          "feedFileStream",
+          <String, dynamic>{
+            "id": id,
+            "fileName": fileName,
+            "data": data,
+            "status": "kWriting",
+          },
+        );
       },
       onDone: () {
         _channel.invokeMethod(
-            "feedFileStream", <String, dynamic>{"id": id, "fileName": fileName, "data": null, "status": "kEnded"});
+          "feedFileStream",
+          <String, dynamic>{
+            "id": id,
+            "fileName": fileName,
+            "data": null,
+            "status": "kEnded",
+          },
+        );
       },
     );
   }

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -14,8 +14,11 @@ class FlutterNativeDragNDrop {
 
   FlutterNativeDragNDrop._();
 
+  /// Used by drop targets
   final _dropListeners = <RawDropListener>{};
-  final _draggableListeners = <d.DraggableState>{};
+
+  /// Used by draggables
+  final _draggableListeners = <UniqueKeyString, d.DraggableState>{};
   late List<NativeDragItem> _draggedItems;
   Offset? _offset;
 
@@ -148,16 +151,16 @@ class FlutterNativeDragNDrop {
       if (id == listener.uniqueKey.toString()) {
         listener.onDragEvent(event);
       }
-    }
+    final listener = _draggableListeners[id];
+    assert(listener != null, "Drag Event for non existent listener");
+    listener?.onDragEvent(event);
   }
 
   _notifyFileStreamEvent(String id, FileStreamEvent event) async {
-    for (final listener in _draggableListeners) {
-      if (id == listener.uniqueKey.toString()) {
-        _listenToFileStream(
-            id, event.fileName, listener.onFileStreamEvent(event));
-      }
-    }
+    final listener = _draggableListeners[id];
+    assert(listener != null, "File Stream Event for non existent listener");
+    if (listener == null) return;
+    _listenToFileStream(id, event.fileName, listener.onFileStreamEvent(event));
   }
 
   _listenToFileStream(String id, String fileName, Stream<Uint8List> stream) {
@@ -176,12 +179,13 @@ class FlutterNativeDragNDrop {
   /// Used by native draggable
   @protected
   void addDraggableListener(d.DraggableState listener) {
-    _draggableListeners.add(listener);
+    _draggableListeners[listener.uniqueKey.toString()] = listener;
   }
 
   /// Used by native draggable
   @protected
   void removeDraggableListener(d.DraggableState listener) {
-    _draggableListeners.remove(listener);
+    _draggableListeners.remove(listener.uniqueKey.toString());
+  }
   }
 }


### PR DESCRIPTION
This PR adds listeners for `DragEvent` to `NativeDragNDrop` and exposes them to package users.

This allows package users to react to general drag events anywhere in the app (e.g. changing some UI whenever some native drag starts or stops)

- Adjusted `NativeDragNDrop`
- Adjusted exports
- Adjusted example